### PR TITLE
feat: comparador multi (comparar_varios + recomendar) + testes

### DIFF
--- a/src/application/comparador.py
+++ b/src/application/comparador.py
@@ -1,25 +1,111 @@
 """
-Comparador de múltiplos resultados de simulação.
-Entrada: dict[str, SimulacaoResultado-like] com atributo `total_pago`.
-Saída: ranking list[(nome_banco, total_pago)] crescente e recomendação textual.
-"""
-from __future__ import annotations
-from typing import Dict, List, Tuple, Optional
+comparador.py
 
-def comparar_varios(resultados: Dict[str, object]) -> List[Tuple[str, float]]:
+Comparador de múltiplos resultados de simulação.
+
+Contratos:
+- Entrada de comparar_varios: dict[str, resultado_like]
+  onde resultado_like expõe `total_pago` como atributo ou como chave em dict.
+- Saída de comparar_varios: List[Tuple[str, float]] (rótulo, total_pago) ordenada por custo crescente.
+  Em caso de empate no total_pago, ordena por rótulo para garantir estabilidade.
+- recomendar recebe ranking (retorno de comparar_varios) e um mapeamento opcional
+  `modalidades: Dict[str, str]` para formatar a recomendação com a modalidade do rótulo.
+- recomendar também aceita parâmetro `tol` (tolerância absoluta) para considerar empates técnicos.
+"""
+
+from __future__ import annotations
+from typing import Dict, List, Tuple, Optional, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def comparar_varios(resultados: Dict[str, Any]) -> List[Tuple[str, float]]:
+    """
+    Converte o dicionário de resultados em uma lista ordenada por total_pago (crescente).
+
+    Aceita:
+      - objetos com atributo `.total_pago`
+      - dicionários com chave 'total_pago'
+
+    Lança:
+      - ValueError se não for possível extrair total_pago de algum resultado.
+
+    Ordenação:
+      - (total_pago, rotulo) para garantir estabilidade em empates.
+    """
     pares: List[Tuple[str, float]] = []
     for nome, obj in resultados.items():
-        total = getattr(obj, "total_pago", None)
+        # Tentativa robusta: atributo primeiro, depois chave em dict
+        total = None
+        try:
+            total = getattr(obj, "total_pago")
+        except Exception:
+            total = None
+
+        if total is None and isinstance(obj, dict):
+            total = obj.get("total_pago")
+
         if total is None:
-            raise AttributeError(f"Objeto resultado de '{nome}' não possui 'total_pago'.")
-        pares.append((nome, float(total)))
-    pares.sort(key=lambda t: t[1])
+            # Mensagem clara para o usuário/dev: contrato de objeto inválido
+            raise ValueError(f"Objeto resultado de '{nome}' não possui 'total_pago' (atributo ou chave).")
+
+        try:
+            total_f = float(total)
+        except Exception as e:
+            raise ValueError(f"Não foi possível converter total_pago do resultado '{nome}' para float: {e}")
+
+        pares.append((nome, total_f))
+
+    # Ordena por total_pago ascendente e, em caso de empate, por rótulo (estabilidade)
+    pares.sort(key=lambda t: (t[1], t[0]))
     return pares
 
-def recomendar(ranking: List[Tuple[str, float]], modalidades: Optional[Dict[str, str]] = None) -> str:
+
+def recomendar(
+    ranking: List[Tuple[str, float]],
+    modalidades: Optional[Dict[str, str]] = None,
+    tol: float = 1e-6
+) -> str:
+    """
+    Gera mensagem de recomendação a partir do ranking.
+
+    Regras:
+      - Se ranking vazio -> mensagem informativa.
+      - Se apenas um item -> retorna recomendação para ele (inclui modalidade se fornecida).
+      - Se há empate técnico (diferença absoluta <= tol entre o menor e outros), retorna mensagem
+        de empate técnico listando os empatados (limitado a 3 para legibilidade).
+      - Caso contrário -> retorna recomendação com o vencedor (inclui modalidade se disponível).
+
+    Parâmetros:
+      - ranking: lista de (rotulo, total_pago) ordenada ascendentemente (retorno de comparar_varios).
+      - modalidades: opcional, mapeia rotulo -> string com o nome da modalidade (ex.: "SAC IPCA+").
+      - tol: tolerância absoluta para considerar empate técnico.
+    """
     if not ranking:
         return "Recomendação: não há resultados para comparar."
-    banco_top, _ = ranking[0]
-    if modalidades and banco_top in modalidades:
-        return f"Recomendação: {banco_top} – {modalidades[banco_top]} com menor custo total."
-    return f"Recomendação: {banco_top} com menor custo total."
+
+    # único candidato: recomendo direto (com modalidade se disponível)
+    if len(ranking) == 1:
+        rotulo, _ = ranking[0]
+        if modalidades and rotulo in modalidades:
+            return f"Recomendação: {rotulo} – {modalidades[rotulo]} com menor custo total."
+        return f"Recomendação: {rotulo} com menor custo total."
+
+    # menor total
+    vencedor, menor_total = ranking[0]
+
+    # coleta todos os rótulos cujo total está dentro da tolerância do menor
+    empatados = [rot for rot, total in ranking if abs(total - menor_total) <= tol]
+
+    if len(empatados) > 1:
+        # Mensagem de empate técnico — lista curta para legibilidade
+        lista = ", ".join(empatados[:3])
+        if len(empatados) > 3:
+            lista += f", e mais {len(empatados) - 3}..."
+        return f"Empate técnico entre: {lista}. Considere regras adicionais (taxas/serviços) para desempate."
+
+    # único vencedor (sem empate técnico)
+    if modalidades and vencedor in modalidades:
+        return f"Recomendação: {vencedor} – {modalidades[vencedor]} com menor custo total."
+    return f"Recomendação: {vencedor} com menor custo total."

--- a/tests/test_comparador_varios.py
+++ b/tests/test_comparador_varios.py
@@ -1,0 +1,130 @@
+"""
+tests/test_comparador_varios.py
+
+Testes para application.comparador:
+- comparar_varios(resultados)
+- recomendar(ranking, modalidades, tol)
+
+Estilo: prints + assert, conforme padrão do repositório.
+"""
+
+import os
+import sys
+
+# garante src no path para imports do projeto
+SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from application.comparador import comparar_varios, recomendar
+
+# --- utilitários de teste ---------------------------------------------------
+
+class DummyResult:
+    """Objeto simples que expõe .total_pago como nos SimulacaoResultado."""
+    def __init__(self, total_pago):
+        self.total_pago = total_pago
+
+def print_header(title: str):
+    print("\n" + title)
+    print("-" * len(title))
+
+# --- casos de teste --------------------------------------------------------
+
+def testar_ranking_basico():
+    print_header("🔧 testar_ranking_basico")
+    resultados = {
+        "Banco A – SAC": DummyResult(1000.0),
+        "Banco B – SAC IPCA+": DummyResult(900.0),
+        "Banco C – SAC": DummyResult(1100.0),
+    }
+
+    ranking = comparar_varios(resultados)
+    print("ranking:", ranking)
+    # menor total deve ser Banco B
+    assert ranking[0][0] == "Banco B – SAC IPCA+"
+    msg = recomendar(ranking)
+    print("mensagem:", msg)
+    assert "Recomendação:" in msg and "Banco B" in msg
+
+def testar_empate_estabilidade_e_tie_break():
+    print_header("🔧 testar_empate_estabilidade_e_tie_break")
+    # Dois bancos com valores muito próximos: ordenação secundária por rótulo (alfabética)
+    # Usamos valores não exatamente iguais para poder testar a tolerância.
+    resultados = {
+        "B": DummyResult(500.000001),  # ligeiramente maior
+        "A": DummyResult(500.0),       # ligeiramente menor
+        "C": DummyResult(600.0),
+    }
+
+    ranking = comparar_varios(resultados)
+    print("ranking (empate aproximado):", ranking)
+    # por estabilidade, A deve aparecer antes de B se os totais fossem iguais;
+    # aqui A tem menor total, portanto vem primeiro
+    assert ranking[0][0] == "A" and ranking[1][0] == "B"
+
+    # testar recomendação com tolerância muito estreita que NÃO considera empate técnico
+    msg_no_empate = recomendar(ranking, tol=1e-9)
+    print("mensagem (sem empate técnico):", msg_no_empate)
+    assert "Recomendação" in msg_no_empate and "A" in msg_no_empate
+
+    # testar empate técnico com tolerância maior (captura valores próximos como empate)
+    msg_empate = recomendar(ranking, tol=1e-1)
+    print("mensagem (empate técnico):", msg_empate)
+    assert "Empate" in msg_empate or "Empate técnico" in msg_empate
+
+
+def testar_modalidades_e_dict_like_results():
+    print_header("🔧 testar_modalidades_e_dict_like_results")
+    # suporte a dicionário no lugar de objeto (dict com chave 'total_pago')
+    resultados = {
+        "Banco X – SAC": {"total_pago": 2000.0},
+        "Banco Y – SAC_IPCA": {"total_pago": 1800.0},
+    }
+    ranking = comparar_varios(resultados)
+    print("ranking (dict-like):", ranking)
+    assert ranking[0][0] == "Banco Y – SAC_IPCA"
+
+    # testar mensagem que inclui modalidade quando fornecida
+    modalidades = {
+        "Banco Y – SAC_IPCA": "SAC IPCA+",
+        "Banco X – SAC": "SAC"
+    }
+    msg = recomendar(ranking, modalidades=modalidades)
+    print("mensagem com modalidades:", msg)
+    assert "SAC IPCA+" in msg or "Banco Y" in msg
+
+def testar_erro_sem_total():
+    print_header("🔧 testar_erro_sem_total")
+    class Bad:
+        pass
+
+    resultados = {"X": Bad()}
+    try:
+        comparar_varios(resultados)
+    except ValueError as e:
+        print("✅ erro esperado (sem total):", e)
+    else:
+        raise AssertionError("❌ Esperado ValueError quando total_pago não existe")
+
+def testar_erro_total_nao_numerico():
+    print_header("🔧 testar_erro_total_nao_numerico")
+    resultados = {"Z": {"total_pago": "não-numérico"}}
+    try:
+        comparar_varios(resultados)
+    except ValueError as e:
+        print("✅ erro esperado (total não numérico):", e)
+    else:
+        raise AssertionError("❌ Esperado ValueError quando total_pago não é conversível para float")
+
+
+# --- execução ---------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("🚀 Executando testes do comparador")
+    testar_ranking_basico()
+    testar_empate_estabilidade_e_tie_break()
+    testar_modalidades_e_dict_like_results()
+    testar_erro_sem_total()
+    testar_erro_total_nao_numerico()
+    print("\n🎯 Todos os testes do comparador passaram (se nenhum assert falhou).")


### PR DESCRIPTION
Resumo
- Adiciona `application/comparador.py` com:
  - `comparar_varios(resultados: dict[str, resultado_like]) -> list[(rotulo, total_pago)]`
    - aceita objeto com atributo `.total_pago` ou dict com chave `total_pago`
    - ordena por (total_pago, rótulo) para estabilidade em empates
  - `recomendar(ranking, modalidades=None, tol=1e-6) -> str`
    - suporte a empate técnico por tolerância
    - suporte opcional a dicionário de modalidades (rotulo -> "SAC"/"SAC IPCA+")
- Testes manuais (prints + assert), sem pytest:
  - `tests/test_comparador_varios.py` cobre ranking básico, empate/tie-break, modalidades, erro sem total_pago e não numérico.

Como testar localmente
```bash
python tests/test_comparador_varios.py
