### PR TITLE
feat: coletor IPCA série 433 com suporte a fixture e teste online/offline

### DIFF
--- a/tests/test_coletor_bacen.py
+++ b/tests/test_coletor_bacen.py
@@ -1,0 +1,55 @@
+"""
+Teste do coletor_bacen.obter_ipca_df usando fixture_csv_path (modo offline).
+Valida:
+- DataFrame retornado contém colunas 'data' e 'ipca'
+- TabelaIPCA.from_dataframe consome sem erro
+"""
+
+import os, sys, tempfile
+import pandas as pd
+
+# garante que src/ esteja no sys.path
+SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from infrastructure.data.coletor_bacen import obter_ipca_df
+from infrastructure.data.tabela_ipca import TabelaIPCA
+
+
+def testar_coletor_fixture():
+    print("\n🔧 testar_coletor_fixture (fixture_csv_path)")
+
+    # cria CSV temporário com 6 meses de IPCA em %
+    content = """data,ipca
+2024-01,0.5
+2024-02,0.4
+2024-03,0.6
+2024-04,0.3
+2024-05,0.45
+2024-06,0.35
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        fixture_path = os.path.join(tmp, "ipca_fixture.csv")
+        with open(fixture_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        df = obter_ipca_df(fixture_csv_path=fixture_path)
+        print("DataFrame retornado:", df.head())
+
+        # checagens básicas
+        assert "data" in df.columns
+        assert "ipca" in df.columns
+        assert len(df) == 6
+
+        # consumir via TabelaIPCA
+        tabela = TabelaIPCA.from_dataframe(df)
+        v1 = tabela.get_ipca(1)
+        print("IPCA fração mês1:", v1)
+        # CSV tinha 0.5% → get_ipca deve retornar 0.005
+        assert abs(v1 - 0.005) < 1e-9
+
+
+if __name__ == "__main__":
+    testar_coletor_fixture()
+    print("\n🎯 Teste coletor_bacen (fixture_csv_path) passou.")

--- a/tests/test_coletor_bacen_online.py
+++ b/tests/test_coletor_bacen_online.py
@@ -1,0 +1,33 @@
+"""
+Teste de integração real com a API do BACEN (série 433 - IPCA).
+- Requer internet ativa.
+- Se a API estiver fora ou sem rede, este teste vai falhar.
+"""
+
+import os, sys
+SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from infrastructure.data.coletor_bacen import obter_ipca_df
+from infrastructure.data.tabela_ipca import TabelaIPCA
+
+def testar_coletor_bacen_online():
+    print("\n🔧 testar_coletor_bacen_online (API real)")
+    df = obter_ipca_df(meses=6)  # chamada real
+
+    print("Primeiras linhas do DataFrame:\n", df.head())
+    assert "data" in df.columns
+    assert "ipca" in df.columns
+    assert not df["ipca"].isna().any(), "Coluna ipca não deveria ter NaN"
+    assert len(df) > 0, "DataFrame deveria ter pelo menos 1 linha"
+
+    # integração com TabelaIPCA
+    tabela = TabelaIPCA.from_dataframe(df)
+    v1 = tabela.get_ipca(1)
+    print("IPCA fração mês1:", v1)
+    assert 0 <= v1 < 0.02, "IPCA (fração) deve estar em faixa plausível (<2%)"
+
+if __name__ == "__main__":
+    testar_coletor_bacen_online()
+    print("\n🎯 Teste coletor_bacen_online passou (API real).")


### PR DESCRIPTION
Resumo
- Adiciona suporte a fixture_csv_path em obter_ipca_df (modo offline).
- Mantém coleta online via bcdata/requests.
- Integração confirmada com TabelaIPCA.from_dataframe.
- Novos testes:
  * test_coletor_bacen.py → fixture offline
  * test_coletor_bacen_online.py → chamada real na API BACEN (433).

Como testar localmente
1. Ative venv
2. python tests/test_coletor_bacen.py
3. python tests/test_coletor_bacen_online.py  # requer internet

Checklist
- [x] Fixture offline passa
- [x] Coleta online retorna DataFrame válido
- [x] Integração com TabelaIPCA funciona
